### PR TITLE
Unify gift certificate meta keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,10 @@ For support, feature requests, or bug reports, please visit our [GitHub reposito
 
 ## Changelog
 
+### Version 1.0.1
+- Unified certificate meta keys
+- Added migration for existing data
+
 ### Version 1.0.0
 - Initial release
 - Fluent Forms Pro integration

--- a/fluentforms-gift-certificates.php
+++ b/fluentforms-gift-certificates.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fluent Forms Gift Certificates
  * Plugin URI: https://github.com/your-username/fluentforms-gift-certificates
  * Description: Generate and manage gift certificates for Fluent Forms with customizable designs and automatic email delivery.
- * Version: 1.0.0
+ * Version: 1.0.1
  * Author: Making The Impact LLC
  * Author URI: https://makingtheimpact.com
  * License: GPL v2 or later
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
 // Define plugin constants
-define('FFGC_VERSION', '1.0.0');
+define('FFGC_VERSION', '1.0.1');
 define('FFGC_PLUGIN_FILE', __FILE__);
 define('FFGC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FFGC_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/includes/class-ffgc-core.php
+++ b/includes/class-ffgc-core.php
@@ -178,8 +178,8 @@ class FFGC_Core {
         
         $certificate = $certificate[0];
         $status = get_post_meta($certificate->ID, '_status', true);
-        $balance = get_post_meta($certificate->ID, '_balance', true);
-        $amount = get_post_meta($certificate->ID, '_amount', true);
+        $balance = get_post_meta($certificate->ID, '_certificate_balance', true);
+        $amount = get_post_meta($certificate->ID, '_certificate_amount', true);
         
         if ($status !== 'active') {
             wp_send_json_error(__('This gift certificate is not active.', 'fluentforms-gift-certificates'));

--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -497,8 +497,8 @@ class FFGC_Forms {
         
         if ($certificate_id) {
             update_post_meta($certificate_id, '_certificate_code', $code);
-            update_post_meta($certificate_id, '_amount', $data['amount']);
-            update_post_meta($certificate_id, '_balance', $data['amount']);
+            update_post_meta($certificate_id, '_certificate_amount', $data['amount']);
+            update_post_meta($certificate_id, '_certificate_balance', $data['amount']);
             update_post_meta($certificate_id, '_recipient_name', $data['recipient_name']);
             update_post_meta($certificate_id, '_recipient_email', $data['recipient_email']);
             update_post_meta($certificate_id, '_design_id', $data['design_id']);
@@ -556,7 +556,7 @@ class FFGC_Forms {
         }
         
         $certificate = $certificate[0];
-        $balance = get_post_meta($certificate->ID, '_balance', true);
+        $balance = get_post_meta($certificate->ID, '_certificate_balance', true);
         $status = get_post_meta($certificate->ID, '_status', true);
         $expiry_date = get_post_meta($certificate->ID, '_expiry_date', true);
         
@@ -574,7 +574,7 @@ class FFGC_Forms {
         $amount_to_apply = $balance;
         
         // Update balance
-        update_post_meta($certificate->ID, '_balance', $balance - $amount_to_apply);
+        update_post_meta($certificate->ID, '_certificate_balance', $balance - $amount_to_apply);
         
         // Log usage
         $this->log_certificate_usage($certificate->ID, $form_id, $submission_id, $amount_to_apply);
@@ -647,7 +647,7 @@ class FFGC_Forms {
         }
         
         $certificate = $certificate[0];
-        $balance = get_post_meta($certificate->ID, '_balance', true);
+        $balance = get_post_meta($certificate->ID, '_certificate_balance', true);
         $status = get_post_meta($certificate->ID, '_status', true);
         $expiry_date = get_post_meta($certificate->ID, '_expiry_date', true);
         
@@ -817,8 +817,8 @@ class FFGC_Forms {
      */
     public function admin_scripts($hook) {
         if (strpos($hook, 'fluent_forms') !== false) {
-            wp_enqueue_script('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/js/admin.js', array('jquery'), '1.0.0', true);
-            wp_enqueue_style('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/css/admin.css', array(), '1.0.0');
+            wp_enqueue_script('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/js/admin.js', array('jquery'), FFGC_VERSION, true);
+            wp_enqueue_style('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/css/admin.css', array(), FFGC_VERSION);
         }
     }
     
@@ -826,8 +826,8 @@ class FFGC_Forms {
      * Enqueue frontend scripts
      */
     public function frontend_scripts() {
-        wp_enqueue_script('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/js/frontend.js', array('jquery'), '1.0.0', true);
-        wp_enqueue_style('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/css/frontend.css', array(), '1.0.0');
+        wp_enqueue_script('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/js/frontend.js', array('jquery'), FFGC_VERSION, true);
+        wp_enqueue_style('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/css/frontend.css', array(), FFGC_VERSION);
         
         wp_localize_script('ffgc-frontend', 'ffgc_ajax', array(
             'ajax_url' => admin_url('admin-ajax.php'),

--- a/includes/class-ffgc-installer.php
+++ b/includes/class-ffgc-installer.php
@@ -237,6 +237,29 @@ class FFGC_Installer {
                 ));
             }
         }
+
+        // Migrate meta keys for certificates
+        if (version_compare($current_version, '1.0.1', '<')) {
+            $certificates = get_posts(array(
+                'post_type' => 'ffgc_certificate',
+                'posts_per_page' => -1,
+                'post_status' => 'any'
+            ));
+
+            foreach ($certificates as $certificate) {
+                $amount = get_post_meta($certificate->ID, '_amount', true);
+                if ($amount !== '') {
+                    update_post_meta($certificate->ID, '_certificate_amount', $amount);
+                    delete_post_meta($certificate->ID, '_amount');
+                }
+
+                $balance = get_post_meta($certificate->ID, '_balance', true);
+                if ($balance !== '') {
+                    update_post_meta($certificate->ID, '_certificate_balance', $balance);
+                    delete_post_meta($certificate->ID, '_balance');
+                }
+            }
+        }
         
         // Update version
         update_option('ffgc_version', FFGC_VERSION);

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fluent-forms, gift-certificates, ecommerce, forms, email, certificates
 Requires at least: 5.0
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.0.0
+Stable tag: 1.0.1
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -124,6 +124,10 @@ Yes! Simply enable the forms you want to use in the plugin settings. Forms with 
 
 == Changelog ==
 
+= 1.0.1 =
+* Unified certificate meta keys
+* Added migration for existing data
+
 = 1.0.0 =
 * Initial release
 * Basic gift certificate functionality
@@ -136,6 +140,9 @@ Yes! Simply enable the forms you want to use in the plugin settings. Forms with 
 * Settings configuration
 
 == Upgrade Notice ==
+
+= 1.0.1 =
+Recommended upgrade to unify certificate meta keys.
 
 = 1.0.0 =
 Initial release of Fluent Forms Gift Certificates plugin.

--- a/templates/admin/main-page.php
+++ b/templates/admin/main-page.php
@@ -59,7 +59,7 @@ if (!defined('ABSPATH')) {
                     ));
                     
                     foreach ($certificates as $certificate) {
-                        $amount = get_post_meta($certificate->ID, '_amount', true);
+                        $amount = get_post_meta($certificate->ID, '_certificate_amount', true);
                         $total_value += floatval($amount);
                     }
                     
@@ -137,7 +137,7 @@ if (!defined('ABSPATH')) {
                     echo '<ul>';
                     foreach ($recent_certificates as $certificate) {
                         $code = get_post_meta($certificate->ID, '_certificate_code', true);
-                        $amount = get_post_meta($certificate->ID, '_amount', true);
+                        $amount = get_post_meta($certificate->ID, '_certificate_amount', true);
                         echo '<li><strong>' . esc_html($certificate->post_title) . '</strong> - ' . esc_html($code) . ' ($' . number_format($amount, 2) . ')</li>';
                     }
                     echo '</ul>';


### PR DESCRIPTION
## Summary
- switch gift certificate meta keys to `_certificate_amount` and `_certificate_balance`
- update create and apply logic
- add database migration for old keys
- bump plugin version to 1.0.1
- document changes in the changelog

## Testing
- `php -l includes/class-ffgc-forms.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686428180130832583eb7b25037927d4