### PR TITLE
Fix gift certificate email method name

### DIFF
--- a/includes/class-ffgc-email.php
+++ b/includes/class-ffgc-email.php
@@ -15,7 +15,14 @@ class FFGC_Email {
         add_filter('wp_mail_content_type', array($this, 'set_html_content_type'));
     }
     
-    public function send_gift_certificate($certificate_id) {
+    /**
+     * Send the gift certificate email to the recipient
+     *
+     * @param int $certificate_id The ID of the certificate post
+     *
+     * @return bool Whether the email was successfully sent
+     */
+    public function send_gift_certificate_email($certificate_id) {
         $certificate = get_post($certificate_id);
         
         if (!$certificate || $certificate->post_type !== 'ffgc_cert') {


### PR DESCRIPTION
## Summary
- rename `FFGC_Email::send_gift_certificate()` to `send_gift_certificate_email()`
- document the method purpose in a docblock

## Testing
- `php -l includes/class-ffgc-email.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68642819bcd08325b68be045ff9e7508