### PR TITLE
Add WooCommerce price fallback

### DIFF
--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -205,7 +205,8 @@ jQuery(document).ready(function($) {
             if (typeof wc_price !== 'undefined') {
                 return wc_price(amount);
             }
-            return '$' + parseFloat(amount).toFixed(2);
+            var symbol = (typeof ffgc_ajax !== 'undefined' && ffgc_ajax.currency_symbol) ? ffgc_ajax.currency_symbol : '$';
+            return symbol + parseFloat(amount).toFixed(2);
         }
     };
 

--- a/fluentforms-gift-certificates.php
+++ b/fluentforms-gift-certificates.php
@@ -31,6 +31,8 @@ define('FFGC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FFGC_PLUGIN_URL', plugin_dir_url(__FILE__));
 define('FFGC_PLUGIN_BASENAME', plugin_basename(__FILE__));
 
+require_once FFGC_PLUGIN_DIR . 'includes/ffgc-utils.php';
+
 // Global flag to prevent multiple initializations
 global $ffgc_initialized;
 $ffgc_initialized = false;

--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -224,12 +224,12 @@ class FFGC_Forms {
                 if ($show_info && ($min_amount || $max_amount)) {
                     echo '<p class="ffgc-design-range">';
                     if ($min_amount && $max_amount) {
-                        echo sprintf(__('Range: %s - %s', 'fluentforms-gift-certificates'), 
-                            wc_price($min_amount), wc_price($max_amount));
+                        echo sprintf(__('Range: %s - %s', 'fluentforms-gift-certificates'),
+                            ffgc_format_price($min_amount), ffgc_format_price($max_amount));
                     } elseif ($min_amount) {
-                        echo sprintf(__('Minimum: %s', 'fluentforms-gift-certificates'), wc_price($min_amount));
+                        echo sprintf(__('Minimum: %s', 'fluentforms-gift-certificates'), ffgc_format_price($min_amount));
                     } elseif ($max_amount) {
-                        echo sprintf(__('Maximum: %s', 'fluentforms-gift-certificates'), wc_price($max_amount));
+                        echo sprintf(__('Maximum: %s', 'fluentforms-gift-certificates'), ffgc_format_price($max_amount));
                     }
                     echo '</p>';
                 }
@@ -666,7 +666,7 @@ class FFGC_Forms {
         wp_send_json_success(array(
             'balance' => $balance,
             'expiry_date' => $expiry_date,
-            'message' => sprintf(__('Certificate valid. Balance: %s', 'fluentforms-gift-certificates'), wc_price($balance))
+            'message' => sprintf(__('Certificate valid. Balance: %s', 'fluentforms-gift-certificates'), ffgc_format_price($balance))
         ));
     }
     
@@ -829,9 +829,11 @@ class FFGC_Forms {
         wp_enqueue_script('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/js/frontend.js', array('jquery'), '1.0.0', true);
         wp_enqueue_style('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/css/frontend.css', array(), '1.0.0');
         
+        $currency = get_option('ffgc_currency', 'USD');
         wp_localize_script('ffgc-frontend', 'ffgc_ajax', array(
             'ajax_url' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('ffgc_nonce')
+            'nonce' => wp_create_nonce('ffgc_nonce'),
+            'currency_symbol' => ffgc_get_currency_symbol($currency)
         ));
     }
     

--- a/includes/ffgc-utils.php
+++ b/includes/ffgc-utils.php
@@ -1,0 +1,29 @@
+<?php
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+if (!function_exists('ffgc_get_currency_symbol')) {
+    function ffgc_get_currency_symbol($currency) {
+        $symbols = array(
+            'USD' => '$',
+            'EUR' => '€',
+            'GBP' => '£',
+            'CAD' => 'C$',
+            'AUD' => 'A$'
+        );
+        return isset($symbols[$currency]) ? $symbols[$currency] : '$';
+    }
+}
+
+if (!function_exists('ffgc_format_price')) {
+    function ffgc_format_price($amount) {
+        if (function_exists('wc_price')) {
+            return wc_price($amount);
+        }
+        $currency = get_option('ffgc_currency', 'USD');
+        $symbol   = ffgc_get_currency_symbol($currency);
+        return $symbol . number_format((float) $amount, 2);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helper `ffgc_format_price()` and currency utilities
- include helpers in main plugin file
- replace direct `wc_price()` calls with fallback formatter
- pass currency symbol to frontend and use when WooCommerce is missing

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864281a37ec8325a16c79bf115a0aaa