### PR TITLE
Improve certificate code generation

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -529,17 +529,18 @@ class FFGC_Forms {
      */
     private function generate_unique_code() {
         do {
-            $code = strtoupper(substr(md5(uniqid()), 0, 12));
+            $code = strtoupper(bin2hex(random_bytes(6)));
             $existing = get_posts(array(
-                'post_type' => 'ffgc_cert',
-                'meta_query' => array(
+                'post_type'      => 'ffgc_cert',
+                'fields'         => 'ids',
+                'meta_query'     => array(
                     array(
-                        'key' => '_certificate_code',
-                        'value' => $code,
-                        'compare' => '='
-                    )
+                        'key'     => '_certificate_code',
+                        'value'   => $code,
+                        'compare' => '=',
+                    ),
                 ),
-                'posts_per_page' => 1
+                'posts_per_page' => 1,
             ));
         } while (!empty($existing));
         

--- a/includes/class-ffgc-post-types.php
+++ b/includes/class-ffgc-post-types.php
@@ -294,8 +294,25 @@ class FFGC_Post_Types {
     }
     
     private function generate_certificate_code() {
-        $prefix = 'GC';
-        $suffix = strtoupper(substr(md5(uniqid()), 0, 6));
-        return $prefix . '-' . $suffix;
+        do {
+            $prefix = 'GC';
+            $suffix = strtoupper(substr(bin2hex(random_bytes(6)), 0, 6));
+            $code   = $prefix . '-' . $suffix;
+
+            $existing = get_posts(array(
+                'post_type'      => 'ffgc_cert',
+                'fields'         => 'ids',
+                'meta_query'     => array(
+                    array(
+                        'key'     => '_certificate_code',
+                        'value'   => $code,
+                        'compare' => '=',
+                    ),
+                ),
+                'posts_per_page' => 1,
+            ));
+        } while (!empty($existing));
+
+        return $code;
     }
 } 


### PR DESCRIPTION
## Summary
- use cryptographically secure random strings when generating codes
- verify new codes are unique before storing

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68643210461c83259f00d82368b03ac5