### PR TITLE
Localize strings for JS

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -36,7 +36,7 @@ jQuery(document).ready(function($) {
                         return '<div class="ffgc-design-field" data-field-id="' + field.attributes.name + '">' +
                                '<input type="hidden" name="' + field.attributes.name + '" value="' + (field.attributes.value || '') + '" ' + (field.attributes.required ? 'required' : '') + ' />' +
                                '<div class="ffgc-design-grid" style="grid-template-columns: repeat(' + (field.settings.columns || 3) + ', 1fr);">' +
-                               '<div class="ffgc-loading-designs">Loading designs...</div>' +
+                               '<div class="ffgc-loading-designs">' + ffgc_strings.loading_designs + '</div>' +
                                '</div>' +
                                '</div>';
                     },
@@ -72,10 +72,10 @@ jQuery(document).ready(function($) {
                         return '<div class="ffgc-redemption-field" data-field-id="' + field.attributes.name + '">' +
                                '<div class="ffgc-code-input-group">' +
                                '<input type="text" name="' + field.attributes.name + '" value="' + (field.attributes.value || '') + '" ' +
-                               'placeholder="' + (field.attributes.placeholder || 'Enter gift certificate code') + '" ' +
+                               'placeholder="' + (field.attributes.placeholder || ffgc_strings.enter_gift_code) + '" ' +
                                (field.attributes.required ? 'required' : '') + ' class="ffgc-certificate-code" ' +
                                'data-auto-apply="' + (field.settings.auto_apply ? 'true' : 'false') + '" />' +
-                               (field.settings.show_balance_check !== false ? '<button type="button" class="ffgc-check-balance-btn">Check Balance</button>' : '') +
+                               (field.settings.show_balance_check !== false ? '<button type="button" class="ffgc-check-balance-btn">' + ffgc_strings.check_balance + '</button>' : '') +
                                '</div>' +
                                '<div class="ffgc-balance-result" style="display: none;"></div>' +
                                '<div class="ffgc-redemption-result" style="display: none;"></div>' +
@@ -165,9 +165,9 @@ jQuery(document).ready(function($) {
                 var $preview = $button.siblings('.ffgc-image-preview');
 
                 var frame = wp.media({
-                    title: 'Select Design Image',
+                    title: ffgc_strings.select_design_image,
                     button: {
-                        text: 'Use this image'
+                        text: ffgc_strings.use_this_image
                     },
                     multiple: false
                 });
@@ -199,17 +199,17 @@ jQuery(document).ready(function($) {
                     success: function(response) {
                         if (response.success) {
                             // Show success message
-                            FFGC_Admin.showMessage('Design status updated successfully', 'success');
+                            FFGC_Admin.showMessage(ffgc_strings.design_status_updated, 'success');
                         } else {
                             // Revert checkbox state
                             $checkbox.prop('checked', !isActive);
-                            FFGC_Admin.showMessage('Failed to update design status', 'error');
+                            FFGC_Admin.showMessage(ffgc_strings.failed_update_design, 'error');
                         }
                     },
                     error: function() {
                         // Revert checkbox state
                         $checkbox.prop('checked', !isActive);
-                        FFGC_Admin.showMessage('An error occurred', 'error');
+                        FFGC_Admin.showMessage(ffgc_strings.error_occurred, 'error');
                     }
                 });
             });
@@ -234,13 +234,13 @@ jQuery(document).ready(function($) {
                     },
                     success: function(response) {
                         if (response.success) {
-                            FFGC_Admin.showMessage('Certificate status updated successfully', 'success');
+                            FFGC_Admin.showMessage(ffgc_strings.certificate_status_updated, 'success');
                         } else {
-                            FFGC_Admin.showMessage('Failed to update certificate status', 'error');
+                            FFGC_Admin.showMessage(ffgc_strings.failed_update_certificate, 'error');
                         }
                     },
                     error: function() {
-                        FFGC_Admin.showMessage('An error occurred', 'error');
+                        FFGC_Admin.showMessage(ffgc_strings.error_occurred, 'error');
                     }
                 });
             });
@@ -255,11 +255,11 @@ jQuery(document).ready(function($) {
                 }).get();
 
                 if (selectedCertificates.length === 0) {
-                    FFGC_Admin.showMessage('Please select certificates to perform this action', 'warning');
+                    FFGC_Admin.showMessage(ffgc_strings.select_certificates, 'warning');
                     return;
                 }
 
-                if (confirm('Are you sure you want to perform this action on ' + selectedCertificates.length + ' certificate(s)?')) {
+                if (confirm(ffgc_strings.confirm_bulk_action.replace('%d', selectedCertificates.length))) {
                     $.ajax({
                         url: ffgc_ajax.ajax_url,
                         type: 'POST',
@@ -271,14 +271,14 @@ jQuery(document).ready(function($) {
                         },
                         success: function(response) {
                             if (response.success) {
-                                FFGC_Admin.showMessage('Bulk action completed successfully', 'success');
+                                FFGC_Admin.showMessage(ffgc_strings.bulk_action_completed, 'success');
                                 location.reload();
                             } else {
-                                FFGC_Admin.showMessage('Failed to perform bulk action', 'error');
+                                FFGC_Admin.showMessage(ffgc_strings.failed_bulk_action, 'error');
                             }
                         },
                         error: function() {
-                            FFGC_Admin.showMessage('An error occurred', 'error');
+                            FFGC_Admin.showMessage(ffgc_strings.error_occurred, 'error');
                         }
                     });
                 }

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -64,7 +64,7 @@ jQuery(document).ready(function($) {
                 var code = $input.val().trim();
 
                 if (!code) {
-                    FFGC.showBalanceResult($field, 'error', 'Please enter a certificate code');
+                    FFGC.showBalanceResult($field, 'error', ffgc_strings.enter_code);
                     return;
                 }
 
@@ -78,7 +78,7 @@ jQuery(document).ready(function($) {
             $(document).on('click', '#ffgc_check_balance', function() {
                 var code = $('#ffgc_certificate_code').val().trim();
                 if (!code) {
-                    FFGC.showBalanceResult($('#ffgc_balance_result'), 'error', 'Please enter a certificate code');
+                    FFGC.showBalanceResult($('#ffgc_balance_result'), 'error', ffgc_strings.enter_code);
                     return;
                 }
                 FFGC.checkBalanceLegacy(code);
@@ -91,7 +91,7 @@ jQuery(document).ready(function($) {
             var $result = $field.find('.ffgc-balance-result');
 
             // Show loading state
-            $btn.prop('disabled', true).text('Checking...');
+            $btn.prop('disabled', true).text(ffgc_strings.checking);
             $result.hide();
 
             $.ajax({
@@ -110,10 +110,10 @@ jQuery(document).ready(function($) {
                     }
                 },
                 error: function() {
-                    FFGC.showBalanceResult($field, 'error', 'An error occurred while checking the certificate');
+                    FFGC.showBalanceResult($field, 'error', ffgc_strings.checking_error);
                 },
                 complete: function() {
-                    $btn.prop('disabled', false).text('Check Balance');
+                    $btn.prop('disabled', false).text(ffgc_strings.check_balance);
                 }
             });
         },
@@ -123,7 +123,7 @@ jQuery(document).ready(function($) {
             var $btn = $('#ffgc_check_balance');
             var $result = $('#ffgc_balance_result');
 
-            $btn.prop('disabled', true).text('Checking...');
+            $btn.prop('disabled', true).text(ffgc_strings.checking);
             $result.hide();
 
             $.ajax({
@@ -142,10 +142,10 @@ jQuery(document).ready(function($) {
                     }
                 },
                 error: function() {
-                    FFGC.showBalanceResult($result, 'error', 'An error occurred while checking the certificate');
+                    FFGC.showBalanceResult($result, 'error', ffgc_strings.checking_error);
                 },
                 complete: function() {
-                    $btn.prop('disabled', false).text('Check Balance');
+                    $btn.prop('disabled', false).text(ffgc_strings.check_balance);
                 }
             });
         },
@@ -176,7 +176,7 @@ jQuery(document).ready(function($) {
                     }
                 },
                 error: function() {
-                    FFGC.showRedemptionResult($field, 'error', 'An error occurred while applying the certificate');
+                    FFGC.showRedemptionResult($field, 'error', ffgc_strings.apply_error);
                 }
             });
         },
@@ -234,8 +234,8 @@ jQuery(document).ready(function($) {
             template: function(field) {
                 return '<div class="ffgc-redemption-field" data-field-id="' + field.attributes.name + '">' +
                        '<div class="ffgc-code-input-group">' +
-                       '<input type="text" name="' + field.attributes.name + '" class="ffgc-certificate-code" placeholder="Enter gift certificate code" />' +
-                       '<button type="button" class="ffgc-check-balance-btn">Check Balance</button>' +
+                       '<input type="text" name="' + field.attributes.name + '" class="ffgc-certificate-code" placeholder="' + ffgc_strings.enter_gift_code + '" />' +
+                       '<button type="button" class="ffgc-check-balance-btn">' + ffgc_strings.check_balance + '</button>' +
                        '</div>' +
                        '<div class="ffgc-balance-result" style="display: none;"></div>' +
                        '<div class="ffgc-redemption-result" style="display: none;"></div>' +
@@ -292,11 +292,11 @@ jQuery(document).ready(function($) {
         var historyDiv = $('#ffgc-usage-history');
         
         if (!code) {
-            resultDiv.html('<div class="ffgc-error">Please enter a gift certificate code.</div>').show();
+            resultDiv.html('<div class="ffgc-error">' + ffgc_strings.enter_code + '.</div>').show();
             return;
         }
         
-        resultDiv.html('<div class="ffgc-loading">Checking balance...</div>').show();
+        resultDiv.html('<div class="ffgc-loading">' + ffgc_strings.checking_balance + '</div>').show();
         historyDiv.hide();
         
         $.ajax({
@@ -327,7 +327,7 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function() {
-                resultDiv.html('<div class="ffgc-error">An error occurred. Please try again.</div>');
+                resultDiv.html('<div class="ffgc-error">' + ffgc_strings.error_occurred + '</div>');
             }
         });
     });
@@ -339,7 +339,7 @@ jQuery(document).ready(function($) {
         var formData = $(this).serialize();
         var resultDiv = $('#ffgc-purchase-result');
         
-        resultDiv.html('<div class="ffgc-loading">Processing...</div>').show();
+        resultDiv.html('<div class="ffgc-loading">' + ffgc_strings.processing + '</div>').show();
         
         $.ajax({
             url: ffgc_ajax.ajax_url,
@@ -354,7 +354,7 @@ jQuery(document).ready(function($) {
                 }
             },
             error: function() {
-                resultDiv.html('<div class="ffgc-error">An error occurred. Please try again.</div>');
+                resultDiv.html('<div class="ffgc-error">' + ffgc_strings.error_occurred + '</div>');
             }
         });
     });
@@ -520,9 +520,9 @@ jQuery(document).ready(function($) {
         
         if (navigator.clipboard) {
             navigator.clipboard.writeText(code).then(function() {
-                button.text('Copied!');
+                button.text(ffgc_strings.copied);
                 setTimeout(function() {
-                    button.text('Copy Code');
+                    button.text(ffgc_strings.copy_code);
                 }, 2000);
             });
         } else {
@@ -534,9 +534,9 @@ jQuery(document).ready(function($) {
             document.execCommand('copy');
             document.body.removeChild(textArea);
             
-            button.text('Copied!');
+            button.text(ffgc_strings.copied);
             setTimeout(function() {
-                button.text('Copy Code');
+                button.text(ffgc_strings.copy_code);
             }, 2000);
         }
     });

--- a/includes/class-ffgc-core.php
+++ b/includes/class-ffgc-core.php
@@ -127,6 +127,7 @@ class FFGC_Core {
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('ffgc_nonce')
         ));
+        wp_localize_script('ffgc-admin', 'ffgc_strings', ffgc_get_script_strings());
     }
     
     public function frontend_scripts() {
@@ -149,6 +150,7 @@ class FFGC_Core {
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('ffgc_nonce')
         ));
+        wp_localize_script('ffgc-frontend', 'ffgc_strings', ffgc_get_script_strings());
     }
     
     public function ajax_check_balance() {

--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -993,6 +993,7 @@ class FFGC_Forms {
         if (strpos($hook, 'fluent_forms') !== false) {
             wp_enqueue_script('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/js/admin.js', array('jquery'), FFGC_VERSION, true);
             wp_enqueue_style('ffgc-admin', plugin_dir_url(__FILE__) . '../assets/css/admin.css', array(), FFGC_VERSION);
+            wp_localize_script('ffgc-admin', 'ffgc_strings', ffgc_get_script_strings());
         }
     }
     
@@ -1002,13 +1003,14 @@ class FFGC_Forms {
     public function frontend_scripts() {
         wp_enqueue_script('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/js/frontend.js', array('jquery'), FFGC_VERSION, true);
         wp_enqueue_style('ffgc-frontend', plugin_dir_url(__FILE__) . '../assets/css/frontend.css', array(), FFGC_VERSION);
-        
+
         $currency = get_option('ffgc_currency', 'USD');
         wp_localize_script('ffgc-frontend', 'ffgc_ajax', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('ffgc_nonce'),
             'currency_symbol' => ffgc_get_currency_symbol($currency)
         ));
+        wp_localize_script('ffgc-frontend', 'ffgc_strings', ffgc_get_script_strings());
     }
     
     /**

--- a/includes/ffgc-utils.php
+++ b/includes/ffgc-utils.php
@@ -27,3 +27,32 @@ if (!function_exists('ffgc_format_price')) {
     }
 }
 
+if (!function_exists('ffgc_get_script_strings')) {
+    function ffgc_get_script_strings() {
+        return array(
+            'loading_designs'          => __('Loading designs...', 'fluentforms-gift-certificates'),
+            'check_balance'            => __('Check Balance', 'fluentforms-gift-certificates'),
+            'checking'                 => __('Checking...', 'fluentforms-gift-certificates'),
+            'error_occurred'           => __('An error occurred', 'fluentforms-gift-certificates'),
+            'enter_code'               => __('Please enter a certificate code', 'fluentforms-gift-certificates'),
+            'design_status_updated'    => __('Design status updated successfully', 'fluentforms-gift-certificates'),
+            'failed_update_design'     => __('Failed to update design status', 'fluentforms-gift-certificates'),
+            'certificate_status_updated' => __('Certificate status updated successfully', 'fluentforms-gift-certificates'),
+            'failed_update_certificate' => __('Failed to update certificate status', 'fluentforms-gift-certificates'),
+            'select_certificates'      => __('Please select certificates to perform this action', 'fluentforms-gift-certificates'),
+            'bulk_action_completed'    => __('Bulk action completed successfully', 'fluentforms-gift-certificates'),
+            'failed_bulk_action'       => __('Failed to perform bulk action', 'fluentforms-gift-certificates'),
+            'confirm_bulk_action'      => __('Are you sure you want to perform this action on %d certificate(s)?', 'fluentforms-gift-certificates'),
+            'checking_error'           => __('An error occurred while checking the certificate', 'fluentforms-gift-certificates'),
+            'apply_error'              => __('An error occurred while applying the certificate', 'fluentforms-gift-certificates'),
+            'checking_balance'         => __('Checking balance...', 'fluentforms-gift-certificates'),
+            'processing'               => __('Processing...', 'fluentforms-gift-certificates'),
+            'copied'                   => __('Copied!', 'fluentforms-gift-certificates'),
+            'copy_code'                => __('Copy Code', 'fluentforms-gift-certificates'),
+            'enter_gift_code'          => __('Enter gift certificate code', 'fluentforms-gift-certificates'),
+            'select_design_image'      => __('Select Design Image', 'fluentforms-gift-certificates'),
+            'use_this_image'           => __('Use this image', 'fluentforms-gift-certificates')
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- add helper returning translated strings
- expose text to admin.js and frontend.js via `wp_localize_script`
- replace hard-coded text in JavaScript with localized strings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6864322737e883259a1d6c4e1df9c2a5