### PR TITLE
Add textdomain loader and languages directory

### DIFF
--- a/fluentforms-gift-certificates.php
+++ b/fluentforms-gift-certificates.php
@@ -123,15 +123,22 @@ function ffgc_check_fluent_forms() {
 // Initialize plugin
 function ffgc_init() {
     global $ffgc_initialized;
-    
+
     // Prevent multiple initializations
     if ($ffgc_initialized) {
         return;
     }
-    
+
     if (!ffgc_check_fluent_forms()) {
         return;
     }
+
+    // Load plugin textdomain for translations
+    load_plugin_textdomain(
+        'fluentforms-gift-certificates',
+        false,
+        dirname(plugin_basename(__FILE__)) . '/languages'
+    );
     
     // Load plugin classes
     require_once FFGC_PLUGIN_DIR . 'includes/class-ffgc-core.php';


### PR DESCRIPTION
## Summary
- load the plugin textdomain during `ffgc_init`
- add empty `languages` directory for translation files

## Testing
- `php -l fluentforms-gift-certificates.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_68643236e5608325afa921f9911c3c6f