### PR TITLE
Fix email template CSS sanitization

### DIFF
--- a/includes/class-ffgc-post-types.php
+++ b/includes/class-ffgc-post-types.php
@@ -210,7 +210,11 @@ class FFGC_Post_Types {
                         $value = floatval($value);
                         break;
                     case 'textarea':
-                        $value = wp_kses_post($value);
+                        if ($key === '_email_template') {
+                            $value = ffgc_sanitize_email_template($value);
+                        } else {
+                            $value = wp_kses_post($value);
+                        }
                         break;
                     default:
                         $value = sanitize_text_field($value);

--- a/includes/ffgc-utils.php
+++ b/includes/ffgc-utils.php
@@ -56,3 +56,18 @@ if (!function_exists('ffgc_get_script_strings')) {
     }
 }
 
+if (!function_exists('ffgc_sanitize_email_template')) {
+    /**
+     * Sanitize email template HTML while allowing style tags.
+     *
+     * @param string $html Raw HTML from the editor.
+     * @return string Sanitized HTML.
+     */
+    function ffgc_sanitize_email_template($html) {
+        $allowed = wp_kses_allowed_html('post');
+        $allowed['style'] = array('type' => true);
+
+        return wp_kses($html, $allowed);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a helper to sanitize email templates while allowing `<style>` tags
- use the helper when saving design meta

## Testing
- `php -l` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_68643658c7f88325af034d50c652f48b