### PR TITLE
Fix custom field templates loading

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -61,8 +61,8 @@ class FFGC_Forms {
         add_action('fluentform_render_item_gift_certificate_design', array($this, 'render_design_field'), 10, 2);
         add_action('fluentform_render_item_gift_certificate_redemption', array($this, 'render_redemption_field'), 10, 2);
         
-        // Add field templates for the editor
-        add_action('wp_footer', array($this, 'add_field_templates'));
+        // Add field templates for the editor in admin area
+        add_action('admin_footer', array($this, 'add_field_templates'));
         
         // Add custom field scripts and styles
         add_action('fluentform_editor_scripts', array($this, 'add_editor_scripts'));


### PR DESCRIPTION
## Summary
- hook `add_field_templates()` to `admin_footer` so templates load in the form editor

## Testing
- `php` not installed, so no syntax checks run

------
https://chatgpt.com/codex/tasks/task_e_686454aec028832598964105fc2c00c1