### PR TITLE
Remove purchase certificate shortcode

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,11 +104,6 @@ A comprehensive WordPress plugin that integrates with Fluent Forms Pro to provid
 ```
 Displays a form to check gift certificate balance.
 
-### Purchase Form
-```
-[gift_certificate_purchase]
-```
-Displays a form to purchase gift certificates.
 
 ### Designs Showcase
 ```

--- a/assets/css/frontend.css
+++ b/assets/css/frontend.css
@@ -178,22 +178,6 @@
     background: #f8f9fa;
 }
 
-/* Purchase Form */
-.ffgc-purchase-form {
-    max-width: 600px;
-    margin: 0 auto;
-    padding: 30px;
-    background: #fff;
-    border-radius: 10px;
-    box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-
-.ffgc-purchase-form h3 {
-    text-align: center;
-    margin-bottom: 30px;
-    color: #333;
-    font-size: 24px;
-}
 
 /* Designs Showcase */
 .ffgc-designs-showcase {
@@ -426,8 +410,7 @@
 
 /* Responsive Design */
 @media (max-width: 768px) {
-    .ffgc-balance-checker,
-    .ffgc-purchase-form {
+    .ffgc-balance-checker {
         padding: 20px;
         margin: 10px;
     }
@@ -467,7 +450,6 @@
 
 @media (max-width: 480px) {
     .ffgc-balance-checker h3,
-    .ffgc-purchase-form h3,
     .ffgc-designs-showcase h3 {
         font-size: 20px;
     }
@@ -516,7 +498,6 @@
     }
     
     .ffgc-balance-checker,
-    .ffgc-purchase-form,
     .ffgc-designs-showcase {
         box-shadow: none;
         border: 1px solid #ccc;

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -332,32 +332,6 @@ jQuery(document).ready(function($) {
         });
     });
     
-    // Handle purchase form submission
-    $(document).on('submit', '#ffgc-purchase-form', function(e) {
-        e.preventDefault();
-        
-        var formData = $(this).serialize();
-        var resultDiv = $('#ffgc-purchase-result');
-        
-        resultDiv.html('<div class="ffgc-loading">' + ffgc_strings.processing + '</div>').show();
-        
-        $.ajax({
-            url: ffgc_ajax.ajax_url,
-            type: 'POST',
-            data: formData + '&action=ffgc_purchase_certificate&nonce=' + ffgc_ajax.nonce,
-            success: function(response) {
-                if (response.success) {
-                    resultDiv.html('<div class="ffgc-success">' + response.data + '</div>');
-                    $('#ffgc-purchase-form')[0].reset();
-                } else {
-                    resultDiv.html('<div class="ffgc-error">' + response.data + '</div>');
-                }
-            },
-            error: function() {
-                resultDiv.html('<div class="ffgc-error">' + ffgc_strings.error_occurred + '</div>');
-            }
-        });
-    });
     
     // Load usage history
     function loadUsageHistory(code) {
@@ -391,46 +365,6 @@ jQuery(document).ready(function($) {
         });
     }
     
-    // Handle design selection in purchase form
-    $(document).on('change', '#ffgc-design-id', function() {
-        var designId = $(this).val();
-        var amountField = $('#ffgc-purchase-amount');
-        
-        if (designId) {
-            // Get design details and update amount limits
-            $.ajax({
-                url: ffgc_ajax.ajax_url,
-                type: 'POST',
-                data: {
-                    action: 'ffgc_get_design_details',
-                    design_id: designId,
-                    nonce: ffgc_ajax.nonce
-                },
-                success: function(response) {
-                    if (response.success) {
-                        amountField.attr('min', response.data.min_amount);
-                        amountField.attr('max', response.data.max_amount);
-                        amountField.next('small').text('Minimum: $' + response.data.min_amount + ', Maximum: $' + response.data.max_amount);
-                    }
-                }
-            });
-        }
-    });
-    
-    // Handle amount validation in purchase form
-    $(document).on('blur', '#ffgc-purchase-amount', function() {
-        var amount = parseFloat($(this).val());
-        var minAmount = parseFloat($(this).attr('min') || 0);
-        var maxAmount = parseFloat($(this).attr('max') || 999999);
-        
-        if (amount < minAmount) {
-            alert('Amount cannot be less than $' + minAmount.toFixed(2));
-            $(this).val(minAmount.toFixed(2));
-        } else if (amount > maxAmount) {
-            alert('Amount cannot be more than $' + maxAmount.toFixed(2));
-            $(this).val(maxAmount.toFixed(2));
-        }
-    });
     
     // Handle form validation
     $('.ffgc-form').on('submit', function() {
@@ -489,10 +423,6 @@ jQuery(document).ready(function($) {
             $('#ffgc-balance-form').submit();
         }
         
-        // Enter key on purchase form
-        if (e.keyCode === 13 && $('#ffgc-purchase-form').length) {
-            $('#ffgc-purchase-form').submit();
-        }
     });
     
     // Handle form field focus for better UX

--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -30,8 +30,6 @@ class FFGC_Forms {
         add_action('wp_ajax_ffgc_bulk_action', array($this, 'ajax_bulk_action'));
 
         // New AJAX handlers
-        add_action('wp_ajax_ffgc_purchase_certificate', array($this, 'ajax_purchase_certificate'));
-        add_action('wp_ajax_nopriv_ffgc_purchase_certificate', array($this, 'ajax_purchase_certificate'));
         add_action('wp_ajax_ffgc_get_design_details', array($this, 'ajax_get_design_details'));
         add_action('wp_ajax_nopriv_ffgc_get_design_details', array($this, 'ajax_get_design_details'));
         add_action('wp_ajax_ffgc_preview_design', array($this, 'ajax_preview_design'));
@@ -894,46 +892,6 @@ class FFGC_Forms {
     /**
      * AJAX: Purchase certificate
      */
-    public function ajax_purchase_certificate() {
-        check_ajax_referer('ffgc_nonce', 'nonce');
-
-        $amount           = floatval($_POST['amount'] ?? 0);
-        $recipient_name   = sanitize_text_field($_POST['recipient_name'] ?? '');
-        $recipient_email  = sanitize_email($_POST['recipient_email'] ?? '');
-        $personal_message = sanitize_textarea_field($_POST['personal_message'] ?? '');
-        $design_id        = intval($_POST['design_id'] ?? 0);
-
-        if ($amount <= 0 || empty($recipient_name) || empty($recipient_email)) {
-            wp_send_json_error(__('Invalid purchase details.', 'fluentforms-gift-certificates'));
-        }
-
-        if ($design_id) {
-            $min = floatval(get_post_meta($design_id, '_min_amount', true));
-            $max = floatval(get_post_meta($design_id, '_max_amount', true));
-            if ($min && $amount < $min) {
-                wp_send_json_error(sprintf(__('Amount must be at least %s', 'fluentforms-gift-certificates'), $min));
-            }
-            if ($max && $amount > $max) {
-                wp_send_json_error(sprintf(__('Amount cannot exceed %s', 'fluentforms-gift-certificates'), $max));
-            }
-        }
-
-        $certificate_id = $this->create_gift_certificate(array(
-            'amount'          => $amount,
-            'recipient_name'  => $recipient_name,
-            'recipient_email' => $recipient_email,
-            'personal_message'=> $personal_message,
-            'design_id'       => $design_id,
-            'submission_id'   => 0
-        ));
-
-        if ($certificate_id) {
-            $this->send_gift_certificate_email($certificate_id);
-            wp_send_json_success(__('Gift certificate purchased successfully.', 'fluentforms-gift-certificates'));
-        }
-
-        wp_send_json_error(__('Failed to create gift certificate.', 'fluentforms-gift-certificates'));
-    }
 
     /**
      * AJAX: Get design details

--- a/includes/class-ffgc-shortcodes.php
+++ b/includes/class-ffgc-shortcodes.php
@@ -13,7 +13,6 @@ class FFGC_Shortcodes {
     
     public function __construct() {
         add_shortcode('gift_certificate_balance', array($this, 'balance_checker_shortcode'));
-        add_shortcode('gift_certificate_purchase', array($this, 'purchase_form_shortcode'));
         add_shortcode('gift_certificate_designs', array($this, 'designs_showcase_shortcode'));
     }
     
@@ -136,116 +135,6 @@ class FFGC_Shortcodes {
         return ob_get_clean();
     }
     
-    public function purchase_form_shortcode($atts) {
-        $atts = shortcode_atts(array(
-            'title' => __('Purchase Gift Certificate', 'fluentforms-gift-certificates'),
-            'show_designs' => 'yes',
-            'min_amount' => '',
-            'max_amount' => ''
-        ), $atts);
-        
-        // Use plugin settings if not specified in shortcode
-        if (empty($atts['min_amount'])) {
-            $atts['min_amount'] = get_option('ffgc_min_amount', 10.00);
-        }
-        if (empty($atts['max_amount'])) {
-            $atts['max_amount'] = get_option('ffgc_max_amount', 1000.00);
-        }
-        
-        ob_start();
-        ?>
-        <div class="ffgc-purchase-form">
-            <h3><?php echo esc_html($atts['title']); ?></h3>
-            
-            <form id="ffgc-purchase-form" class="ffgc-form">
-                <div class="ffgc-field-group">
-                    <label for="ffgc-purchase-amount"><?php _e('Certificate Amount', 'fluentforms-gift-certificates'); ?> *</label>
-                    <input type="number" id="ffgc-purchase-amount" name="amount" min="<?php echo esc_attr($atts['min_amount']); ?>" max="<?php echo esc_attr($atts['max_amount']); ?>" step="0.01" required />
-                    <small><?php printf(__('Minimum: $%s, Maximum: $%s', 'fluentforms-gift-certificates'), number_format($atts['min_amount'], 2), number_format($atts['max_amount'], 2)); ?></small>
-                </div>
-                
-                <div class="ffgc-field-group">
-                    <label for="ffgc-recipient-name"><?php _e('Recipient Name', 'fluentforms-gift-certificates'); ?> *</label>
-                    <input type="text" id="ffgc-recipient-name" name="recipient_name" required />
-                </div>
-                
-                <div class="ffgc-field-group">
-                    <label for="ffgc-recipient-email"><?php _e('Recipient Email', 'fluentforms-gift-certificates'); ?> *</label>
-                    <input type="email" id="ffgc-recipient-email" name="recipient_email" required />
-                </div>
-                
-                <div class="ffgc-field-group">
-                    <label for="ffgc-personal-message"><?php _e('Personal Message', 'fluentforms-gift-certificates'); ?></label>
-                    <textarea id="ffgc-personal-message" name="personal_message" rows="3"></textarea>
-                </div>
-                
-                <?php if ($atts['show_designs'] === 'yes'): ?>
-                    <div class="ffgc-field-group">
-                        <label for="ffgc-design-id"><?php _e('Certificate Design', 'fluentforms-gift-certificates'); ?></label>
-                        <select id="ffgc-design-id" name="design_id">
-                            <option value=""><?php _e('Select a design', 'fluentforms-gift-certificates'); ?></option>
-                            <?php
-                            $designs = get_posts(array(
-                                'post_type' => 'ffgc_design',
-                                'posts_per_page' => -1,
-                                'post_status' => 'publish',
-                                'meta_query' => array(
-                                    array(
-                                        'key' => '_is_active',
-                                        'value' => 'yes',
-                                        'compare' => '='
-                                    )
-                                )
-                            ));
-                            
-                            foreach ($designs as $design) {
-                                echo '<option value="' . esc_attr($design->ID) . '">' . esc_html($design->post_title) . '</option>';
-                            }
-                            ?>
-                        </select>
-                    </div>
-                <?php endif; ?>
-                
-                <button type="submit" class="ffgc-button">
-                    <?php _e('Purchase Gift Certificate', 'fluentforms-gift-certificates'); ?>
-                </button>
-            </form>
-            
-            <div id="ffgc-purchase-result" class="ffgc-result" style="display: none;"></div>
-        </div>
-        
-        <script>
-        jQuery(document).ready(function($) {
-            $('#ffgc-purchase-form').on('submit', function(e) {
-                e.preventDefault();
-                
-                var formData = $(this).serialize();
-                var resultDiv = $('#ffgc-purchase-result');
-                
-                resultDiv.html('<div class="ffgc-loading"><?php _e('Processing...', 'fluentforms-gift-certificates'); ?></div>').show();
-                
-                $.ajax({
-                    url: '<?php echo admin_url('admin-ajax.php'); ?>',
-                    type: 'POST',
-                    data: formData + '&action=ffgc_purchase_certificate&nonce=<?php echo wp_create_nonce('ffgc_nonce'); ?>',
-                    success: function(response) {
-                        if (response.success) {
-                            resultDiv.html('<div class="ffgc-success">' + response.data + '</div>');
-                            $('#ffgc-purchase-form')[0].reset();
-                        } else {
-                            resultDiv.html('<div class="ffgc-error">' + response.data + '</div>');
-                        }
-                    },
-                    error: function() {
-                        resultDiv.html('<div class="ffgc-error"><?php _e('An error occurred. Please try again.', 'fluentforms-gift-certificates'); ?></div>');
-                    }
-                });
-            });
-        });
-        </script>
-        <?php
-        return ob_get_clean();
-    }
     
     public function designs_showcase_shortcode($atts) {
         $atts = shortcode_atts(array(

--- a/readme.txt
+++ b/readme.txt
@@ -46,7 +46,6 @@ Fluent Forms Gift Certificates is a comprehensive WordPress plugin that seamless
 
 **📱 Frontend Shortcodes**
 * `[gift_certificate_balance]` - Check certificate balances
-* `[gift_certificate_purchase]` - Purchase certificates
 * `[gift_certificate_designs]` - Showcase available designs
 
 **⚙️ Configuration Options**

--- a/templates/admin/main-page.php
+++ b/templates/admin/main-page.php
@@ -171,11 +171,6 @@ if (!defined('ABSPATH')) {
                     <p><?php _e('Displays a form to check gift certificate balance.', 'fluentforms-gift-certificates'); ?></p>
                 </div>
                 
-                <div class="ffgc-shortcode-item">
-                    <h4><?php _e('Purchase Form', 'fluentforms-gift-certificates'); ?></h4>
-                    <code>[gift_certificate_purchase]</code>
-                    <p><?php _e('Displays a form to purchase gift certificates.', 'fluentforms-gift-certificates'); ?></p>
-                </div>
                 
                 <div class="ffgc-shortcode-item">
                     <h4><?php _e('Designs Showcase', 'fluentforms-gift-certificates'); ?></h4>

--- a/templates/admin/settings-page.php
+++ b/templates/admin/settings-page.php
@@ -38,7 +38,6 @@ if (!defined('ABSPATH')) {
             <h3><?php _e('3. Use Shortcodes', 'fluentforms-gift-certificates'); ?></h3>
             <ul>
                 <li><code>[gift_certificate_balance]</code> - <?php _e('Check certificate balance', 'fluentforms-gift-certificates'); ?></li>
-                <li><code>[gift_certificate_purchase]</code> - <?php _e('Purchase certificates', 'fluentforms-gift-certificates'); ?></li>
                 <li><code>[gift_certificate_designs]</code> - <?php _e('Show available designs', 'fluentforms-gift-certificates'); ?></li>
             </ul>
         </div>


### PR DESCRIPTION
## Summary
- remove `[gift_certificate_purchase]` shortcode and AJAX actions
- drop purchase form handlers and styles
- update admin pages and docs

## Testing
- `php -l includes/class-ffgc-shortcodes.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_686454b5164c8325b663ca38fcf3a2fa