### PR TITLE
Clear design cache when designs are removed

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -44,6 +44,8 @@ class FFGC_Forms {
         add_action('admin_enqueue_scripts', array($this, 'admin_scripts'));
         add_action('wp_enqueue_scripts', array($this, 'frontend_scripts'));
         add_action('save_post_ffgc_design', array($this, 'clear_design_cache'));
+        add_action('delete_post', array($this, 'maybe_clear_design_cache'));
+        add_action('trashed_post', array($this, 'maybe_clear_design_cache'));
     }
     
     /**
@@ -722,6 +724,15 @@ class FFGC_Forms {
     public function clear_design_cache() {
         delete_transient('ffgc_active_design_ids');
         delete_transient('ffgc_active_design_data');
+    }
+
+    /**
+     * Clear design cache when a design is deleted or trashed
+     */
+    public function maybe_clear_design_cache($post_id) {
+        if (get_post_type($post_id) === 'ffgc_design') {
+            $this->clear_design_cache();
+        }
     }
     
     /**


### PR DESCRIPTION
## Summary
- refresh cached design data when a design is trashed or deleted

## Testing
- `php -l includes/class-ffgc-forms.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686454bf65948325a5e07dbb3bf6b6b6