### PR TITLE
Fix usage history query

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -963,7 +963,7 @@ class FFGC_Forms {
         }
 
         $certificate = get_posts(array(
-            'post_type'  => 'ffgc_certificate',
+            'post_type' => 'ffgc_cert',
             'meta_query' => array(
                 array(
                     'key'   => '_certificate_code',


### PR DESCRIPTION
## Summary
- fix certificate usage history query for the shortcode

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686556f8d35c8325af576cd6b13b7d80