### PR TITLE
Update status meta key

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,10 @@ For support, feature requests, or bug reports, please visit our [GitHub reposito
 
 ## Changelog
 
+### Version 1.0.3
+- Replaced `_certificate_status` meta key with `_status`
+- Migrated existing posts to the new meta key
+
 ### Version 1.0.2
 - Moved certificate usage logs to a dedicated database table
 - Added migration of legacy log meta

--- a/fluentforms-gift-certificates.php
+++ b/fluentforms-gift-certificates.php
@@ -3,7 +3,7 @@
  * Plugin Name: Fluent Forms Gift Certificates
  * Plugin URI: https://github.com/your-username/fluentforms-gift-certificates
  * Description: Generate and manage gift certificates for Fluent Forms with customizable designs and automatic email delivery.
- * Version: 1.0.2
+ * Version: 1.0.3
  * Author: Making The Impact LLC
  * Author URI: https://makingtheimpact.com
  * License: GPL v2 or later
@@ -25,7 +25,7 @@ if (!defined('ABSPATH')) {
 require_once(ABSPATH . 'wp-admin/includes/plugin.php');
 
 // Define plugin constants
-define('FFGC_VERSION', '1.0.2');
+define('FFGC_VERSION', '1.0.3');
 define('FFGC_PLUGIN_FILE', __FILE__);
 define('FFGC_PLUGIN_DIR', plugin_dir_path(__FILE__));
 define('FFGC_PLUGIN_URL', plugin_dir_url(__FILE__));

--- a/includes/class-ffgc-installer.php
+++ b/includes/class-ffgc-installer.php
@@ -296,6 +296,24 @@ class FFGC_Installer {
                 delete_post_meta($certificate->ID, '_usage_log');
             }
         }
+
+        // Migrate certificate status meta key
+        if (version_compare($current_version, '1.0.3', '<')) {
+            $certificates = get_posts(array(
+                'post_type'      => 'ffgc_cert',
+                'posts_per_page' => -1,
+                'post_status'    => 'any',
+            ));
+
+            foreach ($certificates as $certificate) {
+                $old_status = get_post_meta($certificate->ID, '_certificate_status', true);
+                $new_status = get_post_meta($certificate->ID, '_status', true);
+
+                if ($old_status !== '' && $new_status === '') {
+                    update_post_meta($certificate->ID, '_status', $old_status);
+                }
+            }
+        }
         
         // Update version
         update_option('ffgc_version', FFGC_VERSION);

--- a/includes/class-ffgc-post-types.php
+++ b/includes/class-ffgc-post-types.php
@@ -96,7 +96,7 @@ class FFGC_Post_Types {
         
         $code = get_post_meta($post->ID, '_certificate_code', true);
         $amount = get_post_meta($post->ID, '_certificate_amount', true);
-        $status = get_post_meta($post->ID, '_certificate_status', true);
+        $status = get_post_meta($post->ID, '_status', true);
         $used_amount = get_post_meta($post->ID, '_certificate_used_amount', true);
         $recipient_email = get_post_meta($post->ID, '_recipient_email', true);
         $recipient_name = get_post_meta($post->ID, '_recipient_name', true);
@@ -157,7 +157,7 @@ class FFGC_Post_Types {
         $fields = array(
             '_certificate_code' => 'text',
             '_certificate_amount' => 'float',
-            '_certificate_status' => 'text',
+            '_status' => 'text',
             '_certificate_used_amount' => 'float',
             '_recipient_email' => 'email',
             '_recipient_name' => 'text',
@@ -250,7 +250,7 @@ class FFGC_Post_Types {
                 echo esc_html(number_format($amount, 2)) . ' (' . esc_html(number_format($used, 2)) . ' used)';
                 break;
             case 'status':
-                $status = get_post_meta($post_id, '_certificate_status', true);
+                $status = get_post_meta($post_id, '_status', true);
                 $status_class = $status === 'used' ? 'used' : 'unused';
                 echo '<span class="ffgc-status ' . esc_attr($status_class) . '">' . esc_html(ucfirst($status)) . '</span>';
                 break;

--- a/readme.txt
+++ b/readme.txt
@@ -4,7 +4,7 @@ Tags: fluent-forms, gift-certificates, ecommerce, forms, email, certificates
 Requires at least: 5.0
 Tested up to: 6.4
 Requires PHP: 7.4
-Stable tag: 1.0.2
+Stable tag: 1.0.3
 License: GPLv2 or later
 License URI: https://www.gnu.org/licenses/gpl-2.0.html
 
@@ -129,6 +129,10 @@ Yes! Simply enable the forms you want to use in the plugin settings. Forms with 
 
 == Changelog ==
 
+= 1.0.3 =
+* Replaced `_certificate_status` meta key with `_status`
+* Migrated existing posts to the new meta key
+
 = 1.0.2 =
 * Moved usage logs from post meta to a custom table
 * Migrated existing logs during upgrade
@@ -149,6 +153,9 @@ Yes! Simply enable the forms you want to use in the plugin settings. Forms with 
 * Settings configuration
 
 == Upgrade Notice ==
+
+= 1.0.3 =
+Meta key changed from `_certificate_status` to `_status`. Run the upgrade to copy existing data.
 
 = 1.0.2 =
 Database changes for usage logs. Run the upgrade to migrate data.

--- a/templates/admin/meta-boxes/gift-certificate.php
+++ b/templates/admin/meta-boxes/gift-certificate.php
@@ -33,10 +33,10 @@ if (!defined('ABSPATH')) {
     
     <tr>
         <th scope="row">
-            <label for="_certificate_status"><?php _e('Status', 'fluentforms-gift-certificates'); ?></label>
+            <label for="_status"><?php _e('Status', 'fluentforms-gift-certificates'); ?></label>
         </th>
         <td>
-            <select id="_certificate_status" name="_certificate_status">
+            <select id="_status" name="_status">
                 <option value="unused" <?php selected($status, 'unused'); ?>><?php _e('Unused', 'fluentforms-gift-certificates'); ?></option>
                 <option value="used" <?php selected($status, 'used'); ?>><?php _e('Used', 'fluentforms-gift-certificates'); ?></option>
                 <option value="expired" <?php selected($status, 'expired'); ?>><?php _e('Expired', 'fluentforms-gift-certificates'); ?></option>


### PR DESCRIPTION
## Summary
- use new `_status` meta key across admin pages
- update version information
- migrate legacy `_certificate_status` meta key on upgrade

## Testing
- `npm test` *(fails: could not find package.json)*
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686556fc97888325a27372b7504d9b85