### PR TITLE
Add balance URL setting and email placeholder

### DIFF
--- a/includes/class-ffgc-email.php
+++ b/includes/class-ffgc-email.php
@@ -52,7 +52,8 @@ class FFGC_Email {
             'personal_message' => $this->format_personal_message($personal_message),
             'expiry_date' => date('F j, Y', strtotime($expiry_date)),
             'site_name' => get_bloginfo('name'),
-            'site_url' => get_site_url()
+            'site_url' => get_site_url(),
+            'balance_url' => $this->get_balance_url()
         ));
         
         // Email headers
@@ -104,6 +105,17 @@ class FFGC_Email {
     
     public function set_html_content_type() {
         return 'text/html';
+    }
+
+    private function get_balance_url() {
+        $page_id = get_option('ffgc_balance_page', 0);
+        if ($page_id) {
+            $url = get_permalink($page_id);
+            if ($url) {
+                return $url;
+            }
+        }
+        return get_site_url();
     }
     
     private function get_default_template() {
@@ -234,11 +246,13 @@ class FFGC_Email {
                 <ol>
                     <li>Visit our website at <a href="{site_url}">{site_name}</a></li>
                     <li>Add items to your cart</li>
-                    <li>Enter the code above during checkout</li>
-                    <li>Enjoy your purchase!</li>
+                <li>Enter the code above during checkout</li>
+                <li>Enjoy your purchase!</li>
                 </ol>
             </div>
-            
+
+            <p>Check your remaining balance at <a href="{balance_url}">{balance_url}</a>.</p>
+
             {personal_message}
             
             <div class="expiry-notice">

--- a/includes/class-ffgc-installer.php
+++ b/includes/class-ffgc-installer.php
@@ -66,6 +66,7 @@ class FFGC_Installer {
             'ffgc_forms_enabled' => array(),
             'ffgc_gift_certificate_field_label' => __('Gift Certificate Code', 'fluentforms-gift-certificates'),
             'ffgc_gift_certificate_field_placeholder' => __('Enter your gift certificate code', 'fluentforms-gift-certificates'),
+            'ffgc_balance_page' => 0,
         );
         
         foreach ($default_options as $key => $value) {
@@ -135,7 +136,9 @@ class FFGC_Installer {
                 <li>Enter the code above during checkout</li>
                 <li>Enjoy your purchase!</li>
             </ol>
-            
+
+            <p>You can check your remaining balance at <a href="{balance_url}">{balance_url}</a>.</p>
+
             {personal_message}
             
             <p>This gift certificate is valid until {expiry_date}.</p>
@@ -171,6 +174,7 @@ class FFGC_Installer {
             'ffgc_forms_enabled',
             'ffgc_gift_certificate_field_label',
             'ffgc_gift_certificate_field_placeholder',
+            'ffgc_balance_page',
         );
         
         foreach ($options as $option) {

--- a/includes/class-ffgc-settings.php
+++ b/includes/class-ffgc-settings.php
@@ -99,6 +99,12 @@ class FFGC_Settings {
             'sanitize_callback' => array($this, 'sanitize_boolean'),
             'default' => false
         ));
+
+        register_setting('ffgc_settings', 'ffgc_balance_page', array(
+            'type' => 'integer',
+            'sanitize_callback' => 'intval',
+            'default' => 0
+        ));
         
         // Add settings sections
         add_settings_section(
@@ -158,6 +164,14 @@ class FFGC_Settings {
             'ffgc_expiry_days',
             __('Expiry Days', 'fluentforms-gift-certificates'),
             array($this, 'expiry_days_field_callback'),
+            'ffgc_settings',
+            'ffgc_general_settings'
+        );
+
+        add_settings_field(
+            'ffgc_balance_page',
+            __('Balance Page', 'fluentforms-gift-certificates'),
+            array($this, 'balance_page_field_callback'),
             'ffgc_settings',
             'ffgc_general_settings'
         );
@@ -302,6 +316,17 @@ class FFGC_Settings {
         $value = get_option('ffgc_expiry_days', 365);
         echo '<input type="number" min="1" name="ffgc_expiry_days" value="' . esc_attr($value) . '" class="small-text" />';
         echo '<p class="description">' . __('Number of days until gift certificates expire.', 'fluentforms-gift-certificates') . '</p>';
+    }
+
+    public function balance_page_field_callback() {
+        $page_id = get_option('ffgc_balance_page', 0);
+        wp_dropdown_pages(array(
+            'name' => 'ffgc_balance_page',
+            'selected' => $page_id,
+            'show_option_none' => __('— Select —', 'fluentforms-gift-certificates'),
+            'option_none_value' => '0'
+        ));
+        echo '<p class="description">' . __('Page where customers can check gift certificate balances.', 'fluentforms-gift-certificates') . '</p>';
     }
     
     public function email_from_name_field_callback() {

--- a/templates/admin/designs-page.php
+++ b/templates/admin/designs-page.php
@@ -91,7 +91,7 @@ if (!defined('ABSPATH')) {
         <div class="ffgc-tips-grid">
             <div class="ffgc-tip">
                 <h3><?php _e('Email Templates', 'fluentforms-gift-certificates'); ?></h3>
-                <p><?php _e('Use HTML and CSS to create beautiful email templates. Available placeholders: {recipient_name}, {certificate_code}, {amount}, {personal_message}, {expiry_date}, {site_name}, {site_url}', 'fluentforms-gift-certificates'); ?></p>
+                <p><?php _e('Use HTML and CSS to create beautiful email templates. Available placeholders: {recipient_name}, {certificate_code}, {amount}, {personal_message}, {expiry_date}, {site_name}, {site_url}, {balance_url}', 'fluentforms-gift-certificates'); ?></p>
             </div>
             
             <div class="ffgc-tip">

--- a/templates/admin/meta-boxes/design.php
+++ b/templates/admin/meta-boxes/design.php
@@ -56,7 +56,8 @@ if (!defined('ABSPATH')) {
         <code>{personal_message}</code> - <?php _e('Personal message (if provided)', 'fluentforms-gift-certificates'); ?><br>
         <code>{expiry_date}</code> - <?php _e('Expiry date', 'fluentforms-gift-certificates'); ?><br>
         <code>{site_name}</code> - <?php _e('Website name', 'fluentforms-gift-certificates'); ?><br>
-        <code>{site_url}</code> - <?php _e('Website URL', 'fluentforms-gift-certificates'); ?>
+        <code>{site_url}</code> - <?php _e('Website URL', 'fluentforms-gift-certificates'); ?><br>
+        <code>{balance_url}</code> - <?php _e('Balance check page URL', 'fluentforms-gift-certificates'); ?>
     </div>
     
     <?php


### PR DESCRIPTION
## Summary
- allow configuring a page for checking certificate balance
- expose the page selector on the settings page
- add `{balance_url}` placeholder for email templates
- document the new placeholder in template helper text
- include balance URL in default email templates

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865570008288325b8b07bbb39ace654