### PR TITLE
Remove deprecated purchase form options

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -15,10 +15,11 @@ class FFGC_Forms {
         // Fluent Forms hooks
         add_action('fluentform_loaded', array($this, 'register_custom_fields'));
         add_action('fluentform_after_form_render', array($this, 'add_gift_certificate_field'));
-        add_action('fluentform_before_insert_submission', array($this, 'process_gift_certificate_purchase'));
+        // Legacy purchase handling hooks removed
+        // add_action('fluentform_before_insert_submission', array($this, 'process_gift_certificate_purchase'));
         add_action('fluentform_before_insert_submission', array($this, 'process_gift_certificate_application'));
         add_filter('fluentform_form_vars', array($this, 'add_form_vars'));
-        add_action('fluentform_after_payment_success', array($this, 'process_payment_success'));
+        // add_action('fluentform_after_payment_success', array($this, 'process_payment_success'));
         
         // AJAX handlers
         add_action('wp_ajax_ffgc_validate_certificate', array($this, 'ajax_validate_certificate'));
@@ -343,86 +344,21 @@ class FFGC_Forms {
     }
     
     /**
-     * Process gift certificate purchase
+     * Process gift certificate purchase (deprecated)
+     *
+     * @deprecated This logic has been replaced by the REST webhook flow.
      */
     public function process_gift_certificate_purchase($insert_data) {
-        $form_id = $insert_data['form_id'];
-        $enabled_forms = get_option('ffgc_forms_enabled', array());
-        
-        if (!in_array($form_id, $enabled_forms)) {
-            return;
-        }
-        
-        if ($this->get_form_type($form_id) !== 'purchase') {
-            return;
-        }
-        
-        // Get form data
-        $form_data = $insert_data['response'];
-        
-        // Extract gift certificate data
-        $design_id = intval($form_data['gift_certificate_design'] ?? 0);
-        $recipient_name = sanitize_text_field($form_data['recipient_name'] ?? '');
-        $recipient_email = sanitize_email($form_data['recipient_email'] ?? '');
-        $personal_message = sanitize_textarea_field($form_data['personal_message'] ?? '');
-        
-        // Calculate amount from form data
-        $amount = $this->calculate_amount_from_form($form_data);
-        
-        if ($amount <= 0) {
-            return;
-        }
-        
-        // Validate design and amount
-        if ($design_id) {
-            $min_amount = get_post_meta($design_id, '_min_amount', true);
-            $max_amount = get_post_meta($design_id, '_max_amount', true);
-            
-            if ($min_amount && $amount < floatval($min_amount)) {
-                return;
-            }
-            if ($max_amount && $amount > floatval($max_amount)) {
-                return;
-            }
-        }
-        
-        // Store purchase data for later processing after payment
-        update_post_meta($insert_data['id'], '_ffgc_purchase_data', array(
-            'design_id' => $design_id,
-            'recipient_name' => $recipient_name,
-            'recipient_email' => $recipient_email,
-            'personal_message' => $personal_message,
-            'amount' => $amount
-        ));
+        return; // Deprecated
     }
     
     /**
-     * Process payment success
+     * Process payment success (deprecated)
+     *
+     * @deprecated This logic has been replaced by the REST webhook flow.
      */
     public function process_payment_success($submission) {
-        $purchase_data = get_post_meta($submission->id, '_ffgc_purchase_data', true);
-        
-        if (!$purchase_data) {
-            return;
-        }
-        
-        // Create gift certificate
-        $certificate_id = $this->create_gift_certificate(array(
-            'amount' => $purchase_data['amount'],
-            'recipient_name' => $purchase_data['recipient_name'],
-            'recipient_email' => $purchase_data['recipient_email'],
-            'personal_message' => $purchase_data['personal_message'],
-            'design_id' => $purchase_data['design_id'],
-            'submission_id' => $submission->id
-        ));
-        
-        if ($certificate_id) {
-            // Send email to recipient
-            $this->send_gift_certificate_email($certificate_id);
-            
-            // Clear purchase data
-            delete_post_meta($submission->id, '_ffgc_purchase_data');
-        }
+        return; // Deprecated
     }
     
     /**

--- a/includes/class-ffgc-installer.php
+++ b/includes/class-ffgc-installer.php
@@ -63,7 +63,6 @@ class FFGC_Installer {
             'ffgc_email_from_address' => get_option('admin_email'),
             'ffgc_email_subject' => __('Your Gift Certificate is Ready!', 'fluentforms-gift-certificates'),
             'ffgc_default_email_template' => $this->get_default_email_template(),
-            'ffgc_forms_enabled' => array(),
             'ffgc_gift_certificate_field_label' => __('Gift Certificate Code', 'fluentforms-gift-certificates'),
             'ffgc_gift_certificate_field_placeholder' => __('Enter your gift certificate code', 'fluentforms-gift-certificates'),
         );
@@ -168,7 +167,6 @@ class FFGC_Installer {
             'ffgc_email_from_address',
             'ffgc_email_subject',
             'ffgc_default_email_template',
-            'ffgc_forms_enabled',
             'ffgc_gift_certificate_field_label',
             'ffgc_gift_certificate_field_placeholder',
         );

--- a/includes/class-ffgc-settings.php
+++ b/includes/class-ffgc-settings.php
@@ -58,19 +58,7 @@ class FFGC_Settings {
             'default' => __('Your Gift Certificate is Ready!', 'fluentforms-gift-certificates')
         ));
         
-        register_setting('ffgc_settings', 'ffgc_purchase_forms', array(
-            'type' => 'array',
-            'sanitize_callback' => array($this, 'sanitize_forms_array'),
-            'default' => array()
-        ));
-        
         register_setting('ffgc_settings', 'ffgc_redemption_forms', array(
-            'type' => 'array',
-            'sanitize_callback' => array($this, 'sanitize_forms_array'),
-            'default' => array()
-        ));
-        
-        register_setting('ffgc_settings', 'ffgc_forms_enabled', array(
             'type' => 'array',
             'sanitize_callback' => array($this, 'sanitize_forms_array'),
             'default' => array()
@@ -187,14 +175,6 @@ class FFGC_Settings {
         );
         
         add_settings_field(
-            'ffgc_purchase_forms',
-            __('Purchase Forms', 'fluentforms-gift-certificates'),
-            array($this, 'purchase_forms_field_callback'),
-            'ffgc_settings',
-            'ffgc_form_settings'
-        );
-        
-        add_settings_field(
             'ffgc_redemption_forms',
             __('Redemption Forms', 'fluentforms-gift-certificates'),
             array($this, 'redemption_forms_field_callback'),
@@ -202,13 +182,7 @@ class FFGC_Settings {
             'ffgc_form_settings'
         );
         
-        add_settings_field(
-            'ffgc_forms_enabled',
-            __('Legacy: Enable Forms', 'fluentforms-gift-certificates'),
-            array($this, 'forms_enabled_field_callback'),
-            'ffgc_settings',
-            'ffgc_form_settings'
-        );
+
         
         add_settings_field(
             'ffgc_gift_certificate_field_label',
@@ -322,17 +296,11 @@ class FFGC_Settings {
         echo '<p class="description">' . __('Subject line for gift certificate emails.', 'fluentforms-gift-certificates') . '</p>';
     }
     
+    /**
+     * @deprecated No longer configurable via settings.
+     */
     public function purchase_forms_field_callback() {
-        $selected_forms = get_option('ffgc_purchase_forms', array());
-        $forms = $this->get_fluent_forms();
-        
-        echo '<select name="ffgc_purchase_forms[]" multiple style="width: 100%; min-height: 100px;">';
-        foreach ($forms as $form) {
-            $selected = in_array($form->id, $selected_forms) ? 'selected' : '';
-            echo '<option value="' . esc_attr($form->id) . '" ' . $selected . '>' . esc_html($form->title) . '</option>';
-        }
-        echo '</select>';
-        echo '<p class="description">' . __('Select forms that will be used for purchasing gift certificates. These forms should include payment fields and the Gift Certificate Design field type.', 'fluentforms-gift-certificates') . '</p>';
+        echo '<p>' . __('This option has been deprecated.', 'fluentforms-gift-certificates') . '</p>';
     }
     
     public function redemption_forms_field_callback() {
@@ -348,35 +316,11 @@ class FFGC_Settings {
         echo '<p class="description">' . __('Select forms that will allow users to redeem gift certificates. These forms should include the Gift Certificate Redemption field type.', 'fluentforms-gift-certificates') . '</p>';
     }
     
+    /**
+     * @deprecated Legacy form enable option.
+     */
     public function forms_enabled_field_callback() {
-        $enabled_forms = get_option('ffgc_forms_enabled', array());
-        
-        // Check if wpFluent function is available
-        if (!function_exists('wpFluent')) {
-            echo '<p>' . __('Fluent Forms is not properly loaded. Please refresh the page.', 'fluentforms-gift-certificates') . '</p>';
-            return;
-        }
-        
-        // Get all Fluent Forms
-        try {
-            $forms = wpFluent()->table('fluentform_forms')->select(['id', 'title'])->get();
-            
-            if (empty($forms)) {
-                echo '<p>' . __('No Fluent Forms found.', 'fluentforms-gift-certificates') . '</p>';
-                return;
-            }
-            
-            echo '<fieldset>';
-            foreach ($forms as $form) {
-                $checked = in_array($form->id, $enabled_forms) ? 'checked' : '';
-                echo '<label><input type="checkbox" name="ffgc_forms_enabled[]" value="' . esc_attr($form->id) . '" ' . $checked . ' /> ';
-                echo esc_html($form->title) . '</label><br>';
-            }
-            echo '</fieldset>';
-            echo '<p class="description">' . __('Select which forms should have gift certificate functionality.', 'fluentforms-gift-certificates') . '</p>';
-        } catch (Exception $e) {
-            echo '<p>' . __('Error loading Fluent Forms. Please refresh the page.', 'fluentforms-gift-certificates') . '</p>';
-        }
+        echo '<p>' . __('This option has been deprecated.', 'fluentforms-gift-certificates') . '</p>';
     }
     
     public function field_label_callback() {

--- a/templates/admin/forms-page.php
+++ b/templates/admin/forms-page.php
@@ -19,7 +19,6 @@ if (function_exists('wpFluent')) {
     }
 }
 
-$purchase_forms = get_option('ffgc_purchase_forms', array());
 $redemption_forms = get_option('ffgc_redemption_forms', array());
 ?>
 
@@ -27,40 +26,6 @@ $redemption_forms = get_option('ffgc_redemption_forms', array());
     <h1><?php _e('Gift Certificate Forms Configuration', 'fluentforms-gift-certificates'); ?></h1>
     
     <div class="ffgc-forms-config">
-        <div class="ffgc-config-section">
-            <h2><?php _e('Purchase Forms', 'fluentforms-gift-certificates'); ?></h2>
-            <p><?php _e('Configure forms that will be used for purchasing gift certificates. These forms should include payment fields and the Gift Certificate Design field type.', 'fluentforms-gift-certificates'); ?></p>
-            
-            <form method="post" action="options.php">
-                <?php settings_fields('ffgc_settings'); ?>
-                
-                <table class="form-table">
-                    <tr>
-                        <th scope="row"><?php _e('Purchase Forms', 'fluentforms-gift-certificates'); ?></th>
-                        <td>
-                            <select name="ffgc_purchase_forms[]" multiple style="width: 100%; min-height: 150px;">
-                                <?php foreach ($forms as $form): ?>
-                                    <option value="<?php echo esc_attr($form->id); ?>" 
-                                            <?php echo in_array($form->id, $purchase_forms) ? 'selected' : ''; ?>>
-                                        <?php echo esc_html($form->title); ?>
-                                    </option>
-                                <?php endforeach; ?>
-                            </select>
-                            <p class="description">
-                                <?php _e('Hold Ctrl/Cmd to select multiple forms. These forms should include:', 'fluentforms-gift-certificates'); ?>
-                            </p>
-                            <ul class="description">
-                                <li><?php _e('Payment fields (Payment Method, Custom Payment Amount, etc.)', 'fluentforms-gift-certificates'); ?></li>
-                                <li><?php _e('Gift Certificate Design field type', 'fluentforms-gift-certificates'); ?></li>
-                                <li><?php _e('Recipient information fields (Name, Email, Message)', 'fluentforms-gift-certificates'); ?></li>
-                            </ul>
-                        </td>
-                    </tr>
-                </table>
-                
-                <?php submit_button(__('Save Purchase Forms', 'fluentforms-gift-certificates')); ?>
-            </form>
-        </div>
         
         <div class="ffgc-config-section">
             <h2><?php _e('Redemption Forms', 'fluentforms-gift-certificates'); ?></h2>
@@ -118,7 +83,7 @@ $redemption_forms = get_option('ffgc_redemption_forms', array());
                     </li>
                     <li><?php _e('Configure the Custom Payment Amount field with appropriate minimum/maximum values', 'fluentforms-gift-certificates'); ?></li>
                     <li><?php _e('Set up payment methods and gateways', 'fluentforms-gift-certificates'); ?></li>
-                    <li><?php _e('Save the form and add it to the Purchase Forms list above', 'fluentforms-gift-certificates'); ?></li>
+
                 </ol>
                 
                 <h3><?php _e('Redemption Form Setup', 'fluentforms-gift-certificates'); ?></h3>


### PR DESCRIPTION
## Summary
- drop hooks that processed certificate purchases
- mark purchase/payment handlers as deprecated
- remove purchase form settings and update admin guidance
- clean up installer defaults

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865570439b4832584892313a87aeff8