### PR TITLE
Integrate Fluent Forms coupons

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -496,6 +496,8 @@ class FFGC_Forms {
         $certificate_id = wp_insert_post($post_data);
         
         if ($certificate_id) {
+            $expiry = date('Y-m-d H:i:s', strtotime('+' . get_option('ffgc_expiry_days', 365) . ' days'));
+
             update_post_meta($certificate_id, '_certificate_code', $code);
             update_post_meta($certificate_id, '_certificate_amount', $data['amount']);
             update_post_meta($certificate_id, '_certificate_balance', $data['amount']);
@@ -504,9 +506,12 @@ class FFGC_Forms {
             update_post_meta($certificate_id, '_design_id', $data['design_id']);
             update_post_meta($certificate_id, '_submission_id', $data['submission_id']);
             update_post_meta($certificate_id, '_created_date', current_time('mysql'));
-            update_post_meta($certificate_id, '_expiry_date', date('Y-m-d H:i:s', strtotime('+' . get_option('ffgc_expiry_days', 365) . ' days')));
+            update_post_meta($certificate_id, '_expiry_date', $expiry);
             update_post_meta($certificate_id, '_status', 'active');
-            
+
+            // Create matching Fluent Forms coupon
+            ffgc_create_coupon($code, $data['amount'], $expiry);
+
             return $certificate_id;
         }
         
@@ -568,6 +573,7 @@ class FFGC_Forms {
         
         if ($expiry_date && strtotime($expiry_date) < time()) {
             update_post_meta($certificate->ID, '_status', 'expired');
+            ffgc_delete_coupon($code);
             return false;
         }
         
@@ -575,7 +581,13 @@ class FFGC_Forms {
         $amount_to_apply = $balance;
         
         // Update balance
-        update_post_meta($certificate->ID, '_certificate_balance', $balance - $amount_to_apply);
+        $new_balance = $balance - $amount_to_apply;
+        update_post_meta($certificate->ID, '_certificate_balance', $new_balance);
+
+        if ($new_balance <= 0) {
+            update_post_meta($certificate->ID, '_status', 'used');
+            ffgc_delete_coupon($code);
+        }
         
         // Log usage
         $this->log_certificate_usage($certificate->ID, $form_id, $submission_id, $amount_to_apply);

--- a/includes/class-ffgc-webhooks.php
+++ b/includes/class-ffgc-webhooks.php
@@ -115,6 +115,8 @@ class FFGC_Webhooks {
         $certificate_id = wp_insert_post($post_data);
 
         if ($certificate_id) {
+            $expiry = date('Y-m-d H:i:s', strtotime('+' . get_option('ffgc_expiry_days', 365) . ' days'));
+
             update_post_meta($certificate_id, '_certificate_code', $code);
             update_post_meta($certificate_id, '_certificate_amount', $data['amount']);
             update_post_meta($certificate_id, '_certificate_balance', $data['amount']);
@@ -122,8 +124,12 @@ class FFGC_Webhooks {
             update_post_meta($certificate_id, '_recipient_email', $data['recipient_email']);
             update_post_meta($certificate_id, '_design_id', $data['design_id']);
             update_post_meta($certificate_id, '_created_date', current_time('mysql'));
-            update_post_meta($certificate_id, '_expiry_date', date('Y-m-d H:i:s', strtotime('+' . get_option('ffgc_expiry_days', 365) . ' days')));
+            update_post_meta($certificate_id, '_expiry_date', $expiry);
             update_post_meta($certificate_id, '_status', 'active');
+
+            // Create matching Fluent Forms coupon
+            ffgc_create_coupon($code, $data['amount'], $expiry);
+
             return $certificate_id;
         }
         return false;


### PR DESCRIPTION
## Summary
- create/update/delete coupons tied to gift certificates
- generate coupon on certificate creation via forms or webhook
- remove coupon when balance is depleted or certificate expires
- scheduled cleanup of coupons on init

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865570ae87083258dbb44993d6f7933