### PR TITLE
Move JS init calls to end of ready blocks

### DIFF
--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -5,9 +5,6 @@
 jQuery(document).ready(function($) {
     'use strict';
 
-    // Initialize admin functionality
-    FFGC_Admin.init();
-
     // Global FFGC Admin object
     window.FFGC_Admin = {
         init: function() {
@@ -297,6 +294,9 @@ jQuery(document).ready(function($) {
             }, 3000);
         }
     };
+
+    // Initialize admin functionality after object definition
+    FFGC_Admin.init();
 
     // Initialize frontend functionality for admin preview
     if (typeof window.FFGC !== 'undefined') {

--- a/assets/js/frontend.js
+++ b/assets/js/frontend.js
@@ -5,9 +5,6 @@
 jQuery(document).ready(function($) {
     'use strict';
 
-    // Initialize gift certificate functionality
-    FFGC.init();
-
     // Global FFGC object
     window.FFGC = {
         init: function() {
@@ -568,5 +565,7 @@ jQuery(document).ready(function($) {
             }
         `)
         .appendTo('head');
-    
-}); 
+
+    // Initialize gift certificate functionality after object definition
+    FFGC.init();
+});


### PR DESCRIPTION
## Summary
- prevent reference errors by moving initialization calls after object definitions

## Testing
- `node assets/js/admin.js` *(fails: jQuery is not defined)*
- `node assets/js/frontend.js` *(fails: jQuery is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_68655e9f5c248325a75d2a50fe428e8d