### PR TITLE
Fix post author on default design

### DIFF
--- a/includes/class-ffgc-installer.php
+++ b/includes/class-ffgc-installer.php
@@ -82,7 +82,7 @@ class FFGC_Installer {
             'post_content' => __('Default gift certificate design', 'fluentforms-gift-certificates'),
             'post_status' => 'publish',
             'post_type' => 'ffgc_design',
-            'post_author' => 1
+            'post_author' => function_exists('get_current_user_id') ? (get_current_user_id() ?: 0) : 0
         );
         
         $design_id = wp_insert_post($default_design);


### PR DESCRIPTION
## Summary
- use the activating admin as the author of the default design post

## Testing
- `ls`

------
https://chatgpt.com/codex/tasks/task_e_68655ea20c088325920f76f7bf31513c