### PR TITLE
Fix is_active assignment

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -755,7 +755,12 @@ class FFGC_Forms {
         }
         
         $design_id = intval($_POST['design_id'] ?? 0);
-        $is_active = $_POST['is_active'] === 'true';
+
+        if (!isset($_POST['is_active'])) {
+            wp_send_json_error('Missing design status');
+        }
+
+        $is_active = isset($_POST['is_active']) && $_POST['is_active'] === 'true';
         
         if (!$design_id) {
             wp_send_json_error('Invalid design ID');


### PR DESCRIPTION
## Summary
- check if `is_active` was provided when toggling design status
- assign `$is_active` using `isset` check

## Testing
- `php -l includes/class-ffgc-forms.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68656c6a12848325b1dc24c2ceed1608