### PR TITLE
Remove deprecated form options

### DIFF
--- a/includes/class-ffgc-forms.php
+++ b/includes/class-ffgc-forms.php
@@ -14,7 +14,8 @@ class FFGC_Forms {
     public function __construct() {
         // Fluent Forms hooks
         add_action('fluentform_loaded', array($this, 'register_custom_fields'));
-        add_action('fluentform_after_form_render', array($this, 'add_gift_certificate_field'));
+        // Automatic field injection deprecated
+        // add_action('fluentform_after_form_render', array($this, 'add_gift_certificate_field'));
         // Legacy purchase handling hooks removed
         // add_action('fluentform_before_insert_submission', array($this, 'process_gift_certificate_purchase'));
         add_action('fluentform_before_insert_submission', array($this, 'process_gift_certificate_application'));
@@ -281,20 +282,8 @@ class FFGC_Forms {
      * Add gift certificate field to enabled forms
      */
     public function add_gift_certificate_field($form) {
-        $enabled_forms = get_option('ffgc_forms_enabled', array());
-        
-        if (!in_array($form->id, $enabled_forms)) {
-            return;
-        }
-        
-        // Check if this is a gift certificate purchase form or application form
-        $form_type = $this->get_form_type($form->id);
-        
-        if ($form_type === 'purchase') {
-            $this->add_purchase_fields($form);
-        } elseif ($form_type === 'application') {
-            $this->add_application_field($form);
-        }
+        // Deprecated: fields should be added via the form builder.
+        return;
     }
     
     /**
@@ -343,34 +332,12 @@ class FFGC_Forms {
         // This is now handled by the custom redemption field type
     }
     
-    /**
-     * Process gift certificate purchase (deprecated)
-     *
-     * @deprecated This logic has been replaced by the REST webhook flow.
-     */
-    public function process_gift_certificate_purchase($insert_data) {
-        return; // Deprecated
-    }
-    
-    /**
-     * Process payment success (deprecated)
-     *
-     * @deprecated This logic has been replaced by the REST webhook flow.
-     */
-    public function process_payment_success($submission) {
-        return; // Deprecated
-    }
     
     /**
      * Process gift certificate application
      */
     public function process_gift_certificate_application($insert_data) {
         $form_id = $insert_data['form_id'];
-        $enabled_forms = get_option('ffgc_forms_enabled', array());
-        
-        if (!in_array($form_id, $enabled_forms)) {
-            return;
-        }
         
         if ($this->get_form_type($form_id) !== 'application') {
             return;

--- a/includes/class-ffgc-settings.php
+++ b/includes/class-ffgc-settings.php
@@ -342,12 +342,6 @@ class FFGC_Settings {
         echo '<p class="description">' . __('Subject line for gift certificate emails.', 'fluentforms-gift-certificates') . '</p>';
     }
     
-    /**
-     * @deprecated No longer configurable via settings.
-     */
-    public function purchase_forms_field_callback() {
-        echo '<p>' . __('This option has been deprecated.', 'fluentforms-gift-certificates') . '</p>';
-    }
     
     public function redemption_forms_field_callback() {
         $selected_forms = get_option('ffgc_redemption_forms', array());
@@ -362,12 +356,6 @@ class FFGC_Settings {
         echo '<p class="description">' . __('Select forms that will allow users to redeem gift certificates. These forms should include the Gift Certificate Redemption field type.', 'fluentforms-gift-certificates') . '</p>';
     }
     
-    /**
-     * @deprecated Legacy form enable option.
-     */
-    public function forms_enabled_field_callback() {
-        echo '<p>' . __('This option has been deprecated.', 'fluentforms-gift-certificates') . '</p>';
-    }
     
     public function field_label_callback() {
         $value = get_option('ffgc_gift_certificate_field_label', __('Gift Certificate Code', 'fluentforms-gift-certificates'));


### PR DESCRIPTION
## Summary
- drop unused gift certificate form handlers
- drop old options from settings

## Testing
- `php -l includes/class-ffgc-forms.php` *(fails: php not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6866c1cf13c88325a652915e89a64573